### PR TITLE
Update node version to support the newest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "conventional-commit"
   ],
   "engines": {
-    "node": "^10.0.0 || ^12.0.0",
+    "node": ">=10.0.0",
     "yarn": "^1.0.0"
   },
   "main": "index.js",


### PR DESCRIPTION
This package is in the dependencies of https://github.com/holvonix-open/paginate-generator/pull/303, where nice to have support for the `14`/`16` node versions